### PR TITLE
fix: fixes  NotImplementedError('backend does not implement forget.')…

### DIFF
--- a/chirp/settings.py
+++ b/chirp/settings.py
@@ -14,8 +14,6 @@ from pathlib import Path
 import os
 from dotenv import load_dotenv
 
-from chirp.celery import debug_task
-
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -349,5 +347,3 @@ LOGGING = {
         },
     },
 }
-
-debug_task.delay()

--- a/communities/views.py
+++ b/communities/views.py
@@ -132,16 +132,15 @@ class CommunitySearchView(ListAPIView):
         Returns:
             QuerySet[Community]: Filtered and ordered queryset of communities with creator relation selected.
         """
-                
+
         user_id = self.request.user_id or ""
         user = User.objects.get(user_id=user_id)
-        
+
         q = self.request.GET.get("q", "").strip()
 
         blocked_comm_ids = Block.objects.filter(
-            blocker=user, 
-            block_type='community'
-        ).values_list('blocked_community_id', flat=True)
+            blocker=user, block_type="community"
+        ).values_list("blocked_community_id", flat=True)
 
         return (
             Community.objects.filter(Q(description__icontains=q) | Q(name__icontains=q))
@@ -581,7 +580,7 @@ class CommunityLeaveView(DestroyAPIView):
             big_picture=None,
             large_icon=None,
             small_icon=None,
-            url=f"academia:///communities/{community.id}",
+            url=f"academia://communities/{community.id}",
         )
 
         publish(

--- a/posts/views.py
+++ b/posts/views.py
@@ -66,8 +66,8 @@ class PostCreateView(CreateAPIView):
         )
 
         def notify():
-            send_push_notification_to_post_creator.delay(post.id).forget()
-            send_push_notification_to_community_members.delay(post.id).forget()
+            send_push_notification_to_post_creator.delay(post.id)
+            send_push_notification_to_community_members.delay(post.id)
             
         transaction.on_commit(notify)
 


### PR DESCRIPTION
… when creating post

- celery rabbitmq backend does not implement forgetting the result
- removes the call to .forget after notifying users on a new post creation