### PR TITLE
Fix idempotency view to handle bad request response correctly

### DIFF
--- a/interactions/tests.py
+++ b/interactions/tests.py
@@ -8,6 +8,7 @@ from users.models import User
 from interactions.models import Block
 from posts.models import Post
 
+
 class InteractionTestCase(APITestCase):
     def setUp(self):
         self.my_id = "acde070d-8c4c-4f0d-9d8a-162843c10333"
@@ -15,22 +16,21 @@ class InteractionTestCase(APITestCase):
 
         self.me = User.objects.create(user_id=self.my_id, username="me")
         self.other_user = User.objects.create(user_id=self.other_id, username="other")
-        
-        self.auth_headers = {"HTTP_AUTHORIZATION": f"Bearer {os.getenv("TEST_VERISAFE_JWT")}"}
-        
-        self.client.defaults['user_id'] = self.my_id
 
-    @patch('chirp.verisafe_authentication.verify_verisafe_jwt')
+        self.auth_headers = {
+            "HTTP_AUTHORIZATION": f"Bearer {os.getenv("TEST_VERISAFE_JWT")}"
+        }
+
+        self.client.defaults["user_id"] = self.my_id
+
+    @patch("chirp.verisafe_authentication.verify_verisafe_jwt")
     def test_block_user_success(self, mock_verify):
         """Tests that a user can block another user."""
-        
+
         mock_verify.return_value = {"sub": self.my_id, "name": "Tester"}
 
         url = reverse("block-list-create")
-        payload = {
-            "blocked_user": self.other_id,
-            "block_type": "user"
-        }
+        payload = {"blocked_user": self.other_id, "block_type": "user"}
 
         response = self.client.post(url, payload, format="json", **self.auth_headers)
 
@@ -39,24 +39,24 @@ class InteractionTestCase(APITestCase):
             Block.objects.filter(blocker=self.me, blocked_user=self.other_user).exists()
         )
 
-    @patch('chirp.verisafe_authentication.verify_verisafe_jwt')
+    @patch("chirp.verisafe_authentication.verify_verisafe_jwt")
     def test_mutual_blocking_feed_exclusion(self, mock_verify):
         """Tests that mutual blocking works: I shouldn't see posts from someone who blocked me."""
-        
+
         mock_verify.return_value = {"sub": self.my_id}
 
         test_community = Community.objects.create(
             name="Test Community",
             description="A place for testing",
-            creator=self.other_user
+            creator=self.other_user,
         )
 
-        Block.objects.create(blocker=self.other_user, blocked_user=self.me, block_type='user')
+        Block.objects.create(
+            blocker=self.other_user, blocked_user=self.me, block_type="user"
+        )
 
         Post.objects.create(
-            author=self.other_user, 
-            title="Hidden Content", 
-            community=test_community
+            author=self.other_user, title="Hidden Content", community=test_community
         )
 
         url = reverse("post-feed")
@@ -65,88 +65,90 @@ class InteractionTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertNotContains(response, "Hidden Content")
 
-    @patch('chirp.verisafe_authentication.verify_verisafe_jwt')
+    @patch("chirp.verisafe_authentication.verify_verisafe_jwt")
     def test_unblock_user(self, mock_verify):
         """Tests unblocking a user."""
         mock_verify.return_value = {"sub": self.my_id}
-        
-        block = Block.objects.create(blocker=self.me, blocked_user=self.other_user, block_type='user')
-        
+
+        block = Block.objects.create(
+            blocker=self.me, blocked_user=self.other_user, block_type="user"
+        )
+
         url = reverse("unblock", kwargs={"id": block.id})
         response = self.client.delete(url, **self.auth_headers)
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(Block.objects.filter(id=block.id).exists())
 
-    @patch('chirp.verisafe_authentication.verify_verisafe_jwt')
+    @patch("chirp.verisafe_authentication.verify_verisafe_jwt")
     def test_cannot_block_self(self, mock_verify):
         """Ensures a user cannot create a block record for themselves."""
         mock_verify.return_value = {"sub": self.my_id}
-        
+
         url = reverse("block-list-create")
-        payload = {
-            "blocked_user": self.my_id,
-            "block_type": "user"
-        }
+        payload = {"blocked_user": self.my_id, "block_type": "user"}
 
         response = self.client.post(url, payload, format="json", **self.auth_headers)
-        
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("error", response.data)
 
-    @patch('chirp.verisafe_authentication.verify_verisafe_jwt')
+    @patch("chirp.verisafe_authentication.verify_verisafe_jwt")
     def test_duplicate_block_prevention(self, mock_verify):
         """Ensures that a user cannot block the same user twice."""
         mock_verify.return_value = {"sub": self.my_id}
 
-        Block.objects.create(blocker=self.me, blocked_user=self.other_user, block_type='user')
-        
+        Block.objects.create(
+            blocker=self.me, blocked_user=self.other_user, block_type="user"
+        )
+
         url = reverse("block-list-create")
-        payload = {
-            "blocked_user": self.other_id,
-            "block_type": "user"
-        }
-        
+        payload = {"blocked_user": self.other_id, "block_type": "user"}
+
         response = self.client.post(url, payload, format="json", **self.auth_headers)
-        
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    @patch('chirp.verisafe_authentication.verify_verisafe_jwt')
+    @patch("chirp.verisafe_authentication.verify_verisafe_jwt")
     def test_blocked_community_feed_exclusion(self, mock_verify):
         """Tests that blocking a community hides its posts from the feed."""
         mock_verify.return_value = {"sub": self.my_id}
 
         community_to_block = Community.objects.create(
-            name="Spam City",
-            description="Annoying posts here",
-            creator=self.other_user
+            name="Spam City", description="Annoying posts here", creator=self.other_user
         )
 
-        Block.objects.create(blocker=self.me, blocked_community=community_to_block, block_type='community')
+        Block.objects.create(
+            blocker=self.me,
+            blocked_community=community_to_block,
+            block_type="community",
+        )
 
         Post.objects.create(
-            author=self.other_user, 
-            title="Community Post", 
-            community=community_to_block
+            author=self.other_user, title="Community Post", community=community_to_block
         )
 
         response = self.client.get(reverse("post-feed"), **self.auth_headers)
 
         self.assertNotContains(response, "Community Post")
 
-    @patch('chirp.verisafe_authentication.verify_verisafe_jwt')
+    @patch("chirp.verisafe_authentication.verify_verisafe_jwt")
     def test_report_post_success(self, mock_verify):
         """Tests reporting a specific post."""
         mock_verify.return_value = {"sub": self.my_id}
 
-        test_community = Community.objects.create(name="Report Test", creator=self.other_user)
-        reported_post = Post.objects.create(author=self.other_user, title="Offensive", community=test_community)
+        test_community = Community.objects.create(
+            name="Report Test", creator=self.other_user
+        )
+        reported_post = Post.objects.create(
+            author=self.other_user, title="Offensive", community=test_community
+        )
 
         payload = {
             "reported_user": self.other_id,
             "reported_post": reported_post.id,
             "report_type": "post",
-            "reason": "Inappropriate content"
+            "reason": "Inappropriate content",
         }
 
         url = reverse("report-create")
@@ -155,21 +157,29 @@ class InteractionTestCase(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         from interactions.models import Report
-        self.assertTrue(Report.objects.filter(reporter=self.me, reported_post=reported_post).exists())
 
-    @patch('chirp.verisafe_authentication.verify_verisafe_jwt')
+        self.assertTrue(
+            Report.objects.filter(
+                reporter=self.me, reported_post=reported_post
+            ).exists()
+        )
+
+    @patch("chirp.verisafe_authentication.verify_verisafe_jwt")
     def test_unblock_permission_denied(self, mock_verify):
         """Tests that a user cannot delete a block created by someone else."""
         attacker_id = "00000000-0000-0000-0000-000000000000"
         User.objects.create(user_id=attacker_id, username="attacker")
-        
+
         mock_verify.return_value = {"sub": attacker_id}
-        
-        block = Block.objects.create(blocker=self.me, blocked_user=self.other_user, block_type='user')
-        
-        self.client.defaults['user_id'] = attacker_id
+
+        block = Block.objects.create(
+            blocker=self.me, blocked_user=self.other_user, block_type="user"
+        )
+
+        self.client.defaults["user_id"] = attacker_id
         url = reverse("unblock", kwargs={"id": block.id})
-        
+
         response = self.client.delete(url, **self.auth_headers)
-        
+
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+

--- a/posts/apps.py
+++ b/posts/apps.py
@@ -2,14 +2,13 @@ from django.apps import AppConfig
 
 
 class PostsConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'posts'
-
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "posts"
 
     def ready(self) -> None:
         """
         Ensure the app's signal handlers are registered when Django initializes the application.
-        
+
         This method imports the module that registers signal handlers for the posts app (`posts.signals`) so those handlers are connected during app startup.
         """
         import posts.signals

--- a/posts/serializers.py
+++ b/posts/serializers.py
@@ -22,14 +22,14 @@ class AttachmentSerializer(serializers.ModelSerializer):
             validated_data["file_size"] = file.size
             validated_data["original_filename"] = file.name
             file_extension = os.path.splitext(file.name)[1].lower()
-            if file_extension in ['.jpg', '.jpeg', '.png', '.gif', '.bmp']:
+            if file_extension in [".jpg", ".jpeg", ".png", ".gif", ".bmp"]:
                 validated_data["attachment_type"] = "image"
-            elif file_extension in ['.mp4', '.avi', '.mov', '.mkv']:
+            elif file_extension in [".mp4", ".avi", ".mov", ".mkv"]:
                 validated_data["attachment_type"] = "video"
-            elif file_extension in ['.mp3', '.wav', '.aac', '.ogg']:
+            elif file_extension in [".mp3", ".wav", ".aac", ".ogg"]:
                 validated_data["attachment_type"] = "audio"
             else:
-                validated_data["attachment_type"] = "file" 
+                validated_data["attachment_type"] = "file"
         return super().create(validated_data)
 
 
@@ -163,6 +163,7 @@ class PostViewSerializer(serializers.ModelSerializer):
         model = PostView
         fields = ["id", "post", "post_id", "viewer", "viewer_id", "viewed_at"]
         read_only_fields = ["id", "viewed_at"]
+        validators = []
 
 
 class PostVoteSerializer(serializers.ModelSerializer):

--- a/posts/tests.py
+++ b/posts/tests.py
@@ -138,7 +138,7 @@ class RecordPostViewerViewTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     @patch("chirp.verisafe_authentication.verify_verisafe_jwt")
-    def test_record_view_indempotency(self, mock_verify):
+    def test_record_view_idempotency(self, mock_verify):
         mock_verify.return_value = {
             "sub": self.author.user_id,
             "name": self.author.name,

--- a/posts/tests.py
+++ b/posts/tests.py
@@ -164,7 +164,6 @@ class RecordPostViewerViewTests(APITestCase):
             payload,
             **self.auth_headers,
         )
-        print(second_response.json())
         self.assertEqual(second_response.status_code, status.HTTP_200_OK)
         self.post.refresh_from_db()
         self.assertEqual(self.post.views_count, 1)

--- a/posts/tests.py
+++ b/posts/tests.py
@@ -1,7 +1,6 @@
-import os
 from unittest.mock import patch
 import uuid
-from django.test import Client, TestCase
+from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 from datetime import timedelta
@@ -9,9 +8,8 @@ from datetime import timedelta
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from posts.views import RecordPostViewerView
 
-from .models import Post, Community, PostView, User
+from .models import Post, Community, User
 
 
 class PostRankingTest(TestCase):

--- a/posts/tests.py
+++ b/posts/tests.py
@@ -1,5 +1,6 @@
 import os
 from unittest.mock import patch
+import uuid
 from django.test import Client, TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -169,3 +170,25 @@ class RecordPostViewerViewTests(APITestCase):
         self.assertEqual(second_response.status_code, status.HTTP_200_OK)
         self.post.refresh_from_db()
         self.assertEqual(self.post.views_count, 1)
+
+    @patch("chirp.verisafe_authentication.verify_verisafe_jwt")
+    def test_record_view_from_non_existent_user(self, mock_verify):
+        random_uuid = uuid.uuid4()
+        mock_verify.return_value = {
+            "sub": self.author.user_id,
+            "name": self.author.name,
+        }
+
+        url = reverse("record-post-as-viewed", kwargs={"id": self.post.id})
+        payload = {
+            "post_id": self.post.id,
+            "viewer_id": random_uuid,
+        }
+        response = self.client.post(
+            url,
+            payload,
+            **self.auth_headers,
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.post.refresh_from_db()
+        self.assertEqual(self.post.views_count, 0)

--- a/posts/tests.py
+++ b/posts/tests.py
@@ -1,8 +1,16 @@
-from django.test import TestCase
+import os
+from unittest.mock import patch
+from django.test import Client, TestCase
+from django.urls import reverse
 from django.utils import timezone
 from datetime import timedelta
 
-from .models import Post, Community, User
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from posts.views import RecordPostViewerView
+
+from .models import Post, Community, PostView, User
 
 
 class PostRankingTest(TestCase):
@@ -85,3 +93,79 @@ class PostRankingTest(TestCase):
 
         # The post with fewer net points should be lower
         self.assertEqual(feed[0], positive_post)
+
+
+class RecordPostViewerViewTests(APITestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.author = User.objects.create(
+            name="Test User",
+            username="testwriter",
+            email="test@example.com",
+        )
+
+        cls.community = Community.objects.create(
+            name="General", visibility="public", private=False, creator=cls.author
+        )
+
+        cls.post = Post.objects.create(
+            title="Old Legend",
+            author=cls.author,
+            community=cls.community,
+        )
+
+        cls.auth_headers = {"HTTP_AUTHORIZATION": f"Bearer some-random-jwt"}
+
+        cls.url = reverse("record-post-as-viewed", kwargs={"id": cls.post.id})
+
+    @patch("chirp.verisafe_authentication.verify_verisafe_jwt")
+    def test_record_view_success(self, mock_verify):
+        mock_verify.return_value = {
+            "sub": self.author.user_id,
+            "name": self.author.name,
+        }
+
+        url = reverse("record-post-as-viewed", kwargs={"id": self.post.id})
+        payload = {
+            "post_id": self.post.id,
+            "viewer_id": self.author.user_id,
+        }
+
+        response = self.client.post(
+            url,
+            payload,
+            **self.auth_headers,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    @patch("chirp.verisafe_authentication.verify_verisafe_jwt")
+    def test_record_view_indempotency(self, mock_verify):
+        mock_verify.return_value = {
+            "sub": self.author.user_id,
+            "name": self.author.name,
+        }
+
+        url = reverse("record-post-as-viewed", kwargs={"id": self.post.id})
+        payload = {
+            "post_id": self.post.id,
+            "viewer_id": self.author.user_id,
+        }
+
+        first_response = self.client.post(
+            url,
+            payload,
+            **self.auth_headers,
+        )
+        self.assertEqual(first_response.status_code, status.HTTP_200_OK)
+        self.post.refresh_from_db()
+        self.assertEqual(self.post.views_count, 1)
+
+        second_response = self.client.post(
+            url,
+            payload,
+            **self.auth_headers,
+        )
+        print(second_response.json())
+        self.assertEqual(second_response.status_code, status.HTTP_200_OK)
+        self.post.refresh_from_db()
+        self.assertEqual(self.post.views_count, 1)

--- a/posts/views.py
+++ b/posts/views.py
@@ -11,7 +11,7 @@ from rest_framework.generics import (
     ListCreateAPIView,
     RetrieveAPIView,
 )
-from rest_framework.views import Response
+from rest_framework.response import Response
 from communities.models import CommunityMembership
 from interactions.models import Block
 from interactions.utils import get_mutual_blocked_ids

--- a/posts/views.py
+++ b/posts/views.py
@@ -1,6 +1,7 @@
 from django.db import transaction
 from django.db.models import Q, QuerySet
 from django.utils import timezone
+from rest_framework import status
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.fields import ValidationError
 from rest_framework.generics import (
@@ -10,6 +11,7 @@ from rest_framework.generics import (
     ListCreateAPIView,
     RetrieveAPIView,
 )
+from rest_framework.views import Response
 from communities.models import CommunityMembership
 from interactions.models import Block
 from interactions.utils import get_mutual_blocked_ids
@@ -68,7 +70,7 @@ class PostCreateView(CreateAPIView):
         def notify():
             send_push_notification_to_post_creator.delay(post.id)
             send_push_notification_to_community_members.delay(post.id)
-            
+
         transaction.on_commit(notify)
 
 
@@ -229,6 +231,12 @@ class RecordPostViewerView(CreateAPIView):
     """Records a post viewer"""
 
     serializer_class = PostViewSerializer
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
     def perform_create(self, serializer):
         post_id = self.kwargs.get("id")


### PR DESCRIPTION
This pull request introduces the following

**Fixes**
- Initially the post viewing endpoint would return a `400 BAD REQUEST` response for successive calls for valid post views
- The fix consists of bypassing the serializer's validators which were causing the issue and completely delegating this issue to the view's logic

**Tests for post viewing experience**
- The post view endpoint now validates that a post's view is updated once even for successive requests

Please merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the post view recording endpoint, including success scenarios, idempotency verification, and error handling.

* **Style**
  * Standardized code formatting and quote consistency across multiple modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->