### PR TITLE
feat: migrates post migration functionality to the new spec from gossip

### DIFF
--- a/chirp/settings.py
+++ b/chirp/settings.py
@@ -14,6 +14,8 @@ from pathlib import Path
 import os
 from dotenv import load_dotenv
 
+from event_bus import publisher
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -347,3 +349,5 @@ LOGGING = {
         },
     },
 }
+
+publisher.register_shutdown_hook()

--- a/event_bus/models/gossip_monger_notification_payload.py
+++ b/event_bus/models/gossip_monger_notification_payload.py
@@ -10,7 +10,6 @@ class GossipMongerNotificationPayLoad:
     APP_ID: str = "88ca0bb7-c0d7-4e36-b9e6-ea0e29213593"
     SOURCE_SERVICE_ID: str = "io.opencrafts.chirp"
     EVENT_TYPE: str = "push.send"
-    REQUEST_ID: str = str(uuid.uuid4())
 
     def __init__(
         self,
@@ -67,7 +66,7 @@ class GossipMongerNotificationPayLoad:
         meta = {
             "event_type": self.EVENT_TYPE,
             "source_service_id": self.SOURCE_SERVICE_ID,
-            "request_id": self.REQUEST_ID,
+            "request_id": str(uuid.uuid4()),
         }
 
         return json.dumps({"notification": notification, "meta": meta}, indent=4)

--- a/event_bus/models/gossip_monger_notification_payload.py
+++ b/event_bus/models/gossip_monger_notification_payload.py
@@ -1,16 +1,16 @@
 import json
 from typing import List, Dict, Optional
+import uuid
 
-
-GOSSIP_MONGER_EXCHANGE: str = "gossip-monger.exchange"
-GOSSIP_MONGER_ROUTING_KEY: str = "gossip-monger.notification.requested"
+GOSSIP_MONGER_EXCHANGE: str = "gossip.topic.exchange"
+GOSSIP_MONGER_ROUTING_KEY: str = "gossip.push.send"
 
 
 class GossipMongerNotificationPayLoad:
     APP_ID: str = "88ca0bb7-c0d7-4e36-b9e6-ea0e29213593"
     SOURCE_SERVICE_ID: str = "io.opencrafts.chirp"
-    EVENT_TYPE: str = "notification.requested"
-    REQUEST_ID: str = "00000000-0000-0000-0000-000000000000"
+    EVENT_TYPE: str = "push.send"
+    REQUEST_ID: str = str(uuid.uuid4())
 
     def __init__(
         self,

--- a/event_bus/publisher.py
+++ b/event_bus/publisher.py
@@ -15,23 +15,22 @@ def _get_connection():
     )
 
 
-def _publish(exchange: str, queue_name: str, message: str):
+def _publish(exchange: str, routing_key: str, message: str):
     conn = _get_connection()
     ch = conn.channel()
-    ch.queue_declare(queue=queue_name, durable=True)
     ch.basic_publish(
         exchange=exchange,
-        routing_key=queue_name,
+        routing_key=routing_key,
         body=message,
         properties=pika.BasicProperties(delivery_mode=2),
     )
     conn.close()
 
 
-def publish(exchange: str, queue_name: str, message: str):
+def publish(exchange: str, routing_key: str, message: str):
     thread = threading.Thread(
         target=_publish,
-        args=(exchange, queue_name, message),
+        args=(exchange, routing_key, message),
         daemon=True,  # thread won't block Django shutdown
     )
     thread.start()

--- a/event_bus/publisher.py
+++ b/event_bus/publisher.py
@@ -1,36 +1,175 @@
 import pika
 from django.conf import settings
 import threading
+import logging
+import atexit
+
+logger = logging.getLogger(__name__)
 
 
-def _get_connection():
-    creds = pika.PlainCredentials(settings.RABBITMQ_USER, settings.RABBITMQ_PASSWORD)
-    return pika.BlockingConnection(
-        pika.ConnectionParameters(
-            host=settings.RABBITMQ_HOST,
-            port=settings.RABBITMQ_PORT,
-            virtual_host=settings.RABBITMQ_VHOST,
-            credentials=creds,
+class RabbitMQConnection:
+    """Singleton wrapper for a persistent RabbitMQ connection."""
+
+    _instance = None
+    _lock = threading.Lock()
+    _connection = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def get_connection(self):
+        """Get or create the singleton connection."""
+        with self._lock:
+            if self._connection is None or self._connection.is_closed:
+                try:
+                    self._connection = self._create_connection()
+                    logger.info("RabbitMQ connection established")
+                except Exception as e:
+                    logger.error(
+                        "Failed to establish RabbitMQ connection",
+                        extra={
+                            "error_type": type(e).__name__,
+                            "error_message": str(e),
+                        },
+                    )
+                    raise
+            return self._connection
+
+    def _create_connection(self):
+        """Create a new BlockingConnection with configured parameters."""
+        creds = pika.PlainCredentials(
+            settings.RABBITMQ_USER,
+            settings.RABBITMQ_PASSWORD,
         )
-    )
+        return pika.BlockingConnection(
+            pika.ConnectionParameters(
+                host=settings.RABBITMQ_HOST,
+                port=settings.RABBITMQ_PORT,
+                virtual_host=settings.RABBITMQ_VHOST,
+                credentials=creds,
+                socket_timeout=5.0,
+                connection_attempts=3,
+                retry_delay=2,
+            )
+        )
+
+    def close(self):
+        """Close the singleton connection."""
+        with self._lock:
+            if self._connection is not None and not self._connection.is_closed:
+                try:
+                    self._connection.close()
+                    logger.info("RabbitMQ connection closed")
+                except Exception as e:
+                    logger.error(
+                        "Error closing RabbitMQ connection",
+                        extra={
+                            "error_type": type(e).__name__,
+                            "error_message": str(e),
+                        },
+                    )
+                finally:
+                    self._connection = None
 
 
 def _publish(exchange: str, routing_key: str, message: str):
-    conn = _get_connection()
-    ch = conn.channel()
-    ch.basic_publish(
-        exchange=exchange,
-        routing_key=routing_key,
-        body=message,
-        properties=pika.BasicProperties(delivery_mode=2),
-    )
-    conn.close()
+    """Publish a message to RabbitMQ using the singleton connection."""
+    ch = None
+    try:
+        conn = RabbitMQConnection().get_connection()
+        ch = conn.channel()
+
+        # Validate exchange exists before publishing
+        ch.exchange_declare(exchange=exchange, passive=True)
+
+        ch.basic_publish(
+            exchange=exchange,
+            routing_key=routing_key,
+            body=message,
+            properties=pika.BasicProperties(delivery_mode=2),
+        )
+        logger.info(
+            "Message published successfully",
+            extra={
+                "exchange": exchange,
+                "routing_key": routing_key,
+                "message_length": len(message),
+            },
+        )
+    except pika.exceptions.AMQPConnectionError as e:
+        logger.error(
+            "Connection error during publish",
+            extra={
+                "exchange": exchange,
+                "routing_key": routing_key,
+                "error_type": type(e).__name__,
+                "error_message": str(e),
+            },
+        )
+    except pika.exceptions.ChannelError as e:
+        logger.error(
+            "Channel error (exchange may not exist)",
+            extra={
+                "exchange": exchange,
+                "routing_key": routing_key,
+                "error_type": type(e).__name__,
+                "error_message": str(e),
+            },
+        )
+    except Exception as e:
+        logger.error(
+            "Unexpected error during message publish",
+            extra={
+                "exchange": exchange,
+                "routing_key": routing_key,
+                "error_type": type(e).__name__,
+                "error_message": str(e),
+            },
+        )
+    finally:
+        if ch is not None:
+            try:
+                ch.close()
+            except Exception as close_error:
+                logger.warning(
+                    "Error closing channel",
+                    extra={"error_message": str(close_error)},
+                )
 
 
 def publish(exchange: str, routing_key: str, message: str):
+    """Publish a message asynchronously in a daemon thread."""
     thread = threading.Thread(
         target=_publish,
         args=(exchange, routing_key, message),
-        daemon=True,  # thread won't block Django shutdown
+        daemon=True,
     )
     thread.start()
+
+
+def register_shutdown_hook():
+    """
+    Register the RabbitMQ connection cleanup on process exit.
+
+    Call this once during app startup to ensure graceful shutdown.
+
+    Example:
+        from your_library import publisher
+        publisher.register_shutdown_hook()
+    """
+
+    def cleanup():
+        try:
+            RabbitMQConnection().close()
+            logger.info("RabbitMQ connection closed cleanly on shutdown")
+        except Exception as e:
+            logger.error(
+                "Error closing RabbitMQ connection on shutdown",
+                extra={"error_type": type(e).__name__, "error_message": str(e)},
+            )
+
+    atexit.register(cleanup)

--- a/posts/tasks.py
+++ b/posts/tasks.py
@@ -35,7 +35,7 @@ def send_push_notification_to_post_creator(self, post_id: int) -> None:
     notification = GossipMongerNotificationPayLoad(
         headings={"en": "🎉 Your post is live!"},
         contents={
-            "en": f"'{post.title}' is now in {post.community.name}. Share it to get your first 10 likes!"
+            "en": f"'{post.title}' is now in {post.community.name}. Share it to get your first 10 upvotes!"
         },
         subtitle={"en": "Success"},
         target_user_id=author_id,
@@ -48,7 +48,7 @@ def send_push_notification_to_post_creator(self, post_id: int) -> None:
         big_picture=None,
         large_icon=None,
         small_icon=None,
-        url=f"academia://post/{post_id}",
+        url=f"https://academia.opencrafts.io/post/{post_id}",
     )
 
     publish(GOSSIP_MONGER_EXCHANGE, GOSSIP_MONGER_ROUTING_KEY, notification.to_json())
@@ -111,7 +111,7 @@ def send_push_notification_to_community_members(self, post_id: int) -> None:
                 else None
             ),
             small_icon=None,
-            url=f"academia://post/{post_id}",
+            url=f"https://academia.opencrafts.io/post/{post_id}",
         )
         publish(
             GOSSIP_MONGER_EXCHANGE, GOSSIP_MONGER_ROUTING_KEY, notification.to_json()

--- a/posts/tests.py
+++ b/posts/tests.py
@@ -12,6 +12,44 @@ from rest_framework.test import APITestCase
 from .models import Post, Community, User
 
 
+class PostCreateTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.author = User.objects.create(
+            name="Test User",
+            username="testwriter",
+            email="test@example.com",
+        )
+
+        cls.community = Community.objects.create(
+            name="General", visibility="public", private=False, creator=cls.author
+        )
+
+        cls.auth_headers = {"HTTP_AUTHORIZATION": "Bearer some-random-jwt"}
+
+    @patch("chirp.verisafe_authentication.verify_verisafe_jwt")
+    def test_post_create_view(self, mock_verify):
+        mock_verify.return_value = {
+            "sub": self.author.user_id,
+            "name": self.author.name,
+        }
+
+        url = reverse("post-create")
+        payload = {
+            "title": "Pure positivity",
+            "content": "What the title says",
+            "author_id": f"{self.author.user_id}",
+            "community_id": f"{self.community.id}",
+        }
+
+        response = self.client.post(
+            url,
+            payload,
+            **self.auth_headers,
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+
 class PostRankingTest(TestCase):
     def setUp(self):
         """

--- a/posts/views.py
+++ b/posts/views.py
@@ -1,4 +1,4 @@
-from operator import pos
+from django.db import transaction
 from django.db import transaction
 from django.db.models import Q, QuerySet
 from django.utils import timezone

--- a/posts/views.py
+++ b/posts/views.py
@@ -1,3 +1,4 @@
+from operator import pos
 from django.db import transaction
 from django.db.models import Q, QuerySet
 from django.utils import timezone
@@ -28,6 +29,15 @@ from posts.tasks import (
     send_push_notification_to_post_creator,
 )
 from users.models import User
+
+
+def notify_on_post_creation(post_id):
+    """
+    Orchestrator to trigger all asynchronous notification tasks
+    associated with a new post.
+    """
+    send_push_notification_to_post_creator.delay(post_id)
+    send_push_notification_to_community_members.delay(post_id)
 
 
 class PostCreateView(CreateAPIView):
@@ -62,16 +72,12 @@ class PostCreateView(CreateAPIView):
                 {"error": "You must be a member of this community to post."}
             )
 
-        # Save post
-        post = serializer.save(
-            author=user, community=community, created_at=timezone.now()
-        )
+        with transaction.atomic():
+            post = serializer.save(
+                author=user, community=community, created_at=timezone.now()
+            )
 
-        def notify():
-            send_push_notification_to_post_creator.delay(post.id)
-            send_push_notification_to_community_members.delay(post.id)
-
-        transaction.on_commit(notify)
+            transaction.on_commit(lambda: notify_on_post_creation(post.id))
 
 
 class PostAttachmentCreateView(CreateAPIView):


### PR DESCRIPTION
- Chirp now publishes to the new gossip.topic.exchange
- Publishes messages with the gossip.notification.send key
- Pure awesomeness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated post creation notifications to reference "upvotes" instead of "likes"
  * Changed push notification links from app deep-links to web URLs for improved accessibility and cross-platform compatibility
  * Enhanced notification delivery reliability through improved transactional handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->