### PR TITLE
Fix/post notifications

### DIFF
--- a/chirp/settings.py
+++ b/chirp/settings.py
@@ -51,7 +51,6 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "rest_framework",
     "storages",  # For boto3 aws
-    "silk",
     "channels",
     "users",
     "posts",
@@ -107,11 +106,6 @@ WEBSOCKET_HEARTBEAT_INTERVAL = 30
 WEBSOCKET_CONNECTION_TIMEOUT = 300
 WEBSOCKET_MAX_MESSAGE_SIZE = 1024 * 1024
 
-# Silk profiler
-SILKY_PYTHON_PROFILER = True  # Enables the function-level profiler
-SILKY_PYTHON_PROFILER_BINARY = True  # Faster/more efficient binary recording
-SILKY_INTERCEPT_PERCENT = 100  # Percentage of requests to profile (100 for dev/testing)
-
 REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": [],
     "DEFAULT_AUTHENTICATION_CLASSES": [
@@ -165,7 +159,6 @@ CACHES = {
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
-    "silk.middleware.SilkyMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "chirp.middlewares.request_logging_middleware.RequestLoggingMiddleware",
     "django.middleware.common.CommonMiddleware",

--- a/chirp/urls.py
+++ b/chirp/urls.py
@@ -38,7 +38,6 @@ urlpatterns = [
     # path('users/<str:user_id>/permissions/', views.UserPermissionsView.as_view(), name='user_permissions'),
     # path('maintenance/', views.AdminMaintenanceView.as_view(), name='admin_maintenance'),
     path("users/", include("users.urls")),
-    path("silk/", include("silk.urls", namespace="silk")),
     # path('search/', views.UnifiedSearchView.as_view(), name='unified-search'),
 ]
 

--- a/event_bus/models/gossip_monger_notification_payload.py
+++ b/event_bus/models/gossip_monger_notification_payload.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timezone
 from typing import List, Dict, Optional
 import uuid
 
@@ -63,10 +64,13 @@ class GossipMongerNotificationPayLoad:
             "buttons": self.buttons,
         }
 
-        meta = {
+        metadata = {
             "event_type": self.EVENT_TYPE,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "source_service_id": self.SOURCE_SERVICE_ID,
             "request_id": str(uuid.uuid4()),
         }
 
-        return json.dumps({"notification": notification, "meta": meta}, indent=4)
+        return json.dumps(
+            {"notification": notification, "metadata": metadata}, indent=4
+        )

--- a/posts/tasks.py
+++ b/posts/tasks.py
@@ -8,7 +8,7 @@ from event_bus.models.gossip_monger_notification_payload import (
     GossipMongerNotificationPayLoad,
 )
 from event_bus.publisher import publish
-from posts.models import Post
+from posts.models import Comment, Post
 
 logger = logging.getLogger(__name__)
 
@@ -133,3 +133,113 @@ def send_push_notification_to_community_members(self, post_id: int) -> None:
             )
         except Exception as exc:
             raise self.retry(exc=exc)
+
+
+@shared_task(bind=True, max_retries=3)
+def send_push_notification_to_post_author_on_comment(self, comment_id: int) -> None:
+    """
+    Notifies a post's author when someone else comments on their post.
+
+    Skipped when the commenter is the post's author (no self-notify), or
+    when this is a reply whose parent comment's author is also the post's
+    author (send_push_notification_to_parent_comment_author_on_reply
+    already reaches them in that case).
+
+    Args:
+        comment_id: The primary key of the newly created Comment.
+    """
+    try:
+        comment = Comment.objects.select_related("author", "post", "parent").get(
+            id=comment_id
+        )
+    except Comment.DoesNotExist:
+        logger.error(
+            f"Cannot send push notification: Comment with id={comment_id} not found."
+        )
+        return
+
+    post = comment.post
+    if comment.author_id == post.author_id:
+        return
+    if comment.parent is not None and comment.parent.author_id == post.author_id:
+        return
+
+    notification = GossipMongerNotificationPayLoad(
+        headings={"en": "New comment"},
+        contents={
+            "en": f"@{comment.author.username} commented on your post: {comment.content[:100]}"
+        },
+        subtitle={"en": post.title or "Post"},
+        target_user_id=str(post.author_id),
+        include_external_user_ids=[],
+        buttons=[
+            {"id": "view", "text": "View Post", "icon": "ic_visibility"},
+        ],
+        android_channel_id="60023d0b-dcd4-41ae-8e58-7eabbf382c8c",
+        ios_sound="hangout",
+        big_picture=None,
+        large_icon=None,
+        small_icon=None,
+        url=f"https://academia.opencrafts.io/post/{post.id}",
+    )
+
+    try:
+        publish(
+            GOSSIP_MONGER_EXCHANGE, GOSSIP_MONGER_ROUTING_KEY, notification.to_json()
+        )
+    except Exception as exc:
+        raise self.retry(exc=exc)
+
+
+@shared_task(bind=True, max_retries=3)
+def send_push_notification_to_parent_comment_author_on_reply(
+    self, comment_id: int
+) -> None:
+    """
+    Notifies a comment's author when someone else replies to their comment.
+
+    No-op for top-level comments (no parent) or self-replies.
+
+    Args:
+        comment_id: The primary key of the newly created reply Comment.
+    """
+    try:
+        comment = Comment.objects.select_related("author", "post", "parent").get(
+            id=comment_id
+        )
+    except Comment.DoesNotExist:
+        logger.error(
+            f"Cannot send push notification: Comment with id={comment_id} not found."
+        )
+        return
+
+    parent = comment.parent
+    if parent is None or comment.author_id == parent.author_id:
+        return
+
+    post = comment.post
+    notification = GossipMongerNotificationPayLoad(
+        headings={"en": "New reply"},
+        contents={
+            "en": f"@{comment.author.username} replied to your comment: {comment.content[:100]}"
+        },
+        subtitle={"en": post.title or "Post"},
+        target_user_id=str(parent.author_id),
+        include_external_user_ids=[],
+        buttons=[
+            {"id": "view", "text": "View Post", "icon": "ic_visibility"},
+        ],
+        android_channel_id="60023d0b-dcd4-41ae-8e58-7eabbf382c8c",
+        ios_sound="hangout",
+        big_picture=None,
+        large_icon=None,
+        small_icon=None,
+        url=f"https://academia.opencrafts.io/post/{post.id}",
+    )
+
+    try:
+        publish(
+            GOSSIP_MONGER_EXCHANGE, GOSSIP_MONGER_ROUTING_KEY, notification.to_json()
+        )
+    except Exception as exc:
+        raise self.retry(exc=exc)

--- a/posts/tasks.py
+++ b/posts/tasks.py
@@ -51,15 +51,27 @@ def send_push_notification_to_post_creator(self, post_id: int) -> None:
         url=f"https://academia.opencrafts.io/post/{post_id}",
     )
 
-    publish(GOSSIP_MONGER_EXCHANGE, GOSSIP_MONGER_ROUTING_KEY, notification.to_json())
+    try:
+        publish(
+            GOSSIP_MONGER_EXCHANGE, GOSSIP_MONGER_ROUTING_KEY, notification.to_json()
+        )
+    except Exception as exc:
+        raise self.retry(exc=exc)
 
 
-@shared_task(bind=True)
+@shared_task(bind=True, max_retries=3)
 def send_push_notification_to_community_members(self, post_id: int) -> None:
     """
     Sends a push notification to all active, non-banned community members
     (excluding the post author) when a new post is created.
     Batches in groups of 2000 to respect OneSignal's limit.
+
+    TODO: retrying this task re-publishes every batch, including ones that
+    already succeeded, each with a fresh request_id. Since gossip-monger
+    dedupes on request_id, a failure partway through resends duplicate
+    notifications to earlier batches instead of a safe no-op. Fix by
+    splitting into per-batch subtasks (or persisting request_ids per batch)
+    if community sizes grow past a single 2000-member batch.
 
     Args:
         post_id: The primary key of the newly created Post.
@@ -113,6 +125,11 @@ def send_push_notification_to_community_members(self, post_id: int) -> None:
             small_icon=None,
             url=f"https://academia.opencrafts.io/post/{post_id}",
         )
-        publish(
-            GOSSIP_MONGER_EXCHANGE, GOSSIP_MONGER_ROUTING_KEY, notification.to_json()
-        )
+        try:
+            publish(
+                GOSSIP_MONGER_EXCHANGE,
+                GOSSIP_MONGER_ROUTING_KEY,
+                notification.to_json(),
+            )
+        except Exception as exc:
+            raise self.retry(exc=exc)

--- a/posts/views.py
+++ b/posts/views.py
@@ -29,6 +29,8 @@ from posts.serializers import (
 )
 from posts.tasks import (
     send_push_notification_to_community_members,
+    send_push_notification_to_parent_comment_author_on_reply,
+    send_push_notification_to_post_author_on_comment,
     send_push_notification_to_post_creator,
 )
 from users.models import User
@@ -41,6 +43,15 @@ def notify_on_post_creation(post_id):
     """
     send_push_notification_to_post_creator.delay(post_id)
     send_push_notification_to_community_members.delay(post_id)
+
+
+def notify_on_comment_creation(comment_id):
+    """
+    Orchestrator to trigger all asynchronous notification tasks
+    associated with a new comment.
+    """
+    send_push_notification_to_post_author_on_comment.delay(comment_id)
+    send_push_notification_to_parent_comment_author_on_reply.delay(comment_id)
 
 
 class PostCreateView(CreateAPIView):
@@ -378,6 +389,11 @@ class CommentListCreateView(ListCreateAPIView):
         context = super().get_serializer_context()
         context["current_depth"] = 0  # start depth counting
         return context
+
+    def perform_create(self, serializer):
+        with transaction.atomic():
+            comment = serializer.save()
+            transaction.on_commit(lambda: notify_on_comment_creation(comment.id))
 
 
 class CommentRetrieveView(RetrieveAPIView):

--- a/posts/views.py
+++ b/posts/views.py
@@ -3,7 +3,6 @@ from django.db import transaction
 from django.db.models import Q, QuerySet
 from django.utils import timezone
 from rest_framework import status
-from silk.profiling.profiler import silk_profile
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.fields import ValidationError
 from rest_framework.generics import (
@@ -136,7 +135,6 @@ class PostsFeedView(ListAPIView):
 
     serializer_class = PostSerializer
 
-    @silk_profile(name="Feed QuerySet Construction")
     def get_queryset(self):
         user_id = getattr(self.request, "user_id", None)
         if not user_id:

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,6 @@ constantly==23.10.4
 cryptography==47.0.0
 daphne==4.2.1
 Django==6.0.4
-django-silk==5.5.0
 django-storages==1.14.6
 django-stubs==6.0.3
 django-stubs-ext==6.0.3

--- a/utils/migrations/0001_drop_silk_tables.py
+++ b/utils/migrations/0001_drop_silk_tables.py
@@ -1,0 +1,28 @@
+from django.db import migrations
+
+# django-silk was removed from INSTALLED_APPS (it was profiling 100% of
+# production requests with the binary function profiler, causing the
+# performance problems it was meant to help diagnose). Its tables are
+# orphaned now that the app is gone, so drop them directly by name rather
+# than through the ORM. IF EXISTS makes this a no-op on any environment
+# that never had silk migrated (e.g. a fresh database).
+DROP_SILK_TABLES_SQL = """
+DROP TABLE IF EXISTS silk_profile_queries CASCADE;
+DROP TABLE IF EXISTS silk_profile CASCADE;
+DROP TABLE IF EXISTS silk_response CASCADE;
+DROP TABLE IF EXISTS silk_sqlquery CASCADE;
+DROP TABLE IF EXISTS silk_request CASCADE;
+"""
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.RunSQL(
+            sql=DROP_SILK_TABLES_SQL,
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+    ]


### PR DESCRIPTION
Summary

- Push notifications weren't sending: the gossip-monger payload was built with the wrong top-level key (meta instead of metadata), so source_service_id was never read and every message was rejected as outside the io.opencrafts namespace.
- Notification Celery tasks declared max_retries=3 but never actually retried on failure — a transient publish error silently dropped the notification.
- New feature: post authors and comment authors now get notified on new comments/replies.
- Removed django-silk — it was profiling 100% of production requests with the binary profiler enabled, which was itself a production performance problem. Also drops its now-orphaned DB tables.

Changes

Notification pipeline fix (event_bus/models/gossip_monger_notification_payload.py)
- Rename the outbound payload's top-level meta key to metadata to match gossip-monger's integration spec.
- Add the required timestamp field, which was missing entirely.
- Also fixes notifications dispatched from communities/views.py, since it shares the same payload builder.

Retry logic fix (posts/tasks.py)
- Wrap publish() calls in both post-creation notification tasks with try/except + self.retry(exc=exc) so max_retries=3 actually does something.
- Add max_retries=3 explicitly to send_push_notification_to_community_members.

New: comment notifications (posts/tasks.py, posts/views.py)
- Notify a post's author when someone else comments on their post, and a comment's author when someone else replies to it.
- Self-comments/self-replies skipped; if a reply's parent comment author is also the post author, only the more specific "reply" notification fires.
- Wired into CommentListCreateView.perform_create via transaction.on_commit.
- Verified all four dedup cases against a test DB with publish mocked.

Remove django-silk (chirp/settings.py, chirp/urls.py, posts/views.py, requirements.txt)
- SILKY_INTERCEPT_PERCENT = 100 + binary profiler with no dev/prod gating meant every production request was fully profiled and written to the DB — the actual cause of the slowdown.

Drop silk's tables (utils/migrations/0001_drop_silk_tables.py)
- Raw-SQL migration dropping the 5 orphaned silk tables, verified via sqlmigrate and applied locally.

Test plan

- [x] manage.py check, manage.py test posts
- [x] Verified broker/exchange/binding independently before finding the payload bug
- [x] Mocked-publish verification of comment-notification dedup logic
- [x] Migration verified via sqlmigrate + applied locally, tables confirmed dropped


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added notifications for post authors when comments are created.
  - Added notifications for comment authors when replies are posted.
  - Notification events now include UTC timestamps and expanded metadata.

- **Bug Fixes**
  - Improved notification reliability with automatic retries for temporary failures.
  - Notifications are dispatched after comments are successfully saved.

- **Chores**
  - Removed the performance-profiling interface and related configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->