### PR TITLE
fix(worker): pin celery to solo pool to stop OOMKilling

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: sh -c "python manage.py migrate && (python manage.py run_consumers &) && gunicorn --workers 1 --bind 0.0.0.0:8000 chirp.wsgi:application --access-logfile - --error-logfile -"
-worker: celery -A chirp worker -l info
+worker: celery -A chirp worker -l info --pool=solo


### PR DESCRIPTION
celery -A chirp worker had no --pool/--concurrency flag, so it defaulted to prefork with one child process per visible CPU core. Kubernetes CPU limits are CFS-throttled, not affinity-masked, so os.cpu_count() inside the container reports the node's full core count -- the worker was forking far more full Django processes than the pod's memory limit could hold, causing repeated OOMKilled restarts in staging.

Switch to --pool=solo: a single process, no forking. Tasks here are small I/O-bound publish calls (bounded by publisher.py's 5s socket timeout + 3 retries), so serial execution within one pod is an acceptable tradeoff for a bounded, predictable memory footprint.